### PR TITLE
Rename develop to main and remove master

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Please note the following guidelines before submitting pull requests:
 
 - Use the [PSR-2 coding style](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
 - All new features must be covered by unit tests
-- Always create pull requests to the *develop* branch
+- Always create pull requests to the *main* branch

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Lumen SparkPost
 
-[![Build Status](https://travis-ci.org/nordsoftware/lumen-sparkpost.svg?branch=master)](https://travis-ci.org/nordsoftware/lumen-sparkpost)
-[![Coverage Status](https://coveralls.io/repos/github/nordsoftware/lumen-sparkpost/badge.svg?branch=master)](https://coveralls.io/github/nordsoftware/lumen-sparkpost?branch=master)
+[![Build Status](https://travis-ci.org/nordsoftware/lumen-sparkpost.svg?branch=main)](https://travis-ci.org/nordsoftware/lumen-sparkpost)
+[![Coverage Status](https://coveralls.io/repos/github/nordsoftware/lumen-sparkpost/badge.svg?branch=main)](https://coveralls.io/github/nordsoftware/lumen-sparkpost?branch=main)
 [![Code Climate](https://codeclimate.com/github/nordsoftware/lumen-sparkpost/badges/gpa.svg)](https://codeclimate.com/github/nordsoftware/lumen-sparkpost)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nordsoftware/lumen-sparkpost/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nordsoftware/lumen-sparkpost/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nordsoftware/lumen-sparkpost/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/nordsoftware/lumen-sparkpost/?branch=main)
 [![Latest Stable Version](https://poser.pugx.org/nordsoftware/lumen-sparkpost/version)](https://packagist.org/packages/nordsoftware/lumen-sparkpost)
 [![Total Downloads](https://poser.pugx.org/nordsoftware/lumen-sparkpost/downloads)](https://packagist.org/packages/nordsoftware/lumen-sparkpost)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
Let's ditch using two `develop` + `master` branches and use only a single default branch.

Let's also rename the default to `main` at the same time.

Currently `master` is behind `develop`:

![image](https://user-images.githubusercontent.com/1324225/160780576-9b6b94bb-b436-47fa-821c-924de3d4080f.png)

So deleting `master` and renaming `develop` to `main`.

