### PR TITLE
Test PHP 7.2-7.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["5.6", "7.0", "7.1"]
+        php-version: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Changes proposed in this pull request:

 * Test PHP 7.2-7.4
 * 8.0-8.1 will need more work, PRs welcome
 * 5.6-7.3 are EOL and can be dropped: https://endoflife.date/php

| cycle | latest |  release   |  support   |    eol     |
|:------|:-------|:----------:|:----------:|:----------:|
| 8.1   | 8.1.4  | 2021-11-25 | 2023-11-25 | 2024-11-25 |
| 8.0   | 8.0.17 | 2020-11-26 | 2022-11-26 | 2023-11-26 |
| 7.4   | 7.4.28 | 2019-11-28 | 2021-11-28 | 2022-11-28 |
| 7.3   | 7.3.33 | 2018-12-06 | 2020-12-06 | 2021-12-06 |
| 7.2   | 7.2.34 | 2017-11-30 | 2019-11-30 | 2020-11-30 |
| 7.1   | 7.1.33 | 2016-12-01 | 2018-12-01 | 2019-12-01 |
| 7.0   | 7.0.33 | 2015-12-03 | 2018-01-04 | 2019-01-10 |
| 5.6   | 5.6.40 | 2014-08-28 | 2017-01-19 | 2018-12-31 |

